### PR TITLE
Make bundler optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ for rubocopfmt to work.
 This ensures that formatting is done with the same version of RuboCop that the
 project lists as a dependency.
 
+If you don't care about having a specific version of RuboCop and/or are using it as an
+external tool, but still use a `Gemfile`, you can opt out from this behaviour by configuring
+the option `(setq rubocopfmt-use-bundler-when-possible nil)`.
+
 ## Disabled Cops
 
 There's a few of cops in RuboCop that can cause confusion and annoyance when run

--- a/rubocopfmt.el
+++ b/rubocopfmt.el
@@ -58,6 +58,11 @@
   :type 'string
   :group 'rubocopfmt)
 
+(defcustom rubocopfmt-use-bundler-when-possible t
+  "When t and Gemfile is present, run rubocop with 'bundle exec'."
+  :type 'boolean
+  :group 'rubocopfmt)
+
 (defcustom rubocopfmt-disabled-cops
   '("Lint/Debugger"              ; Don't remove debugger calls.
     "Lint/UnusedBlockArgument"   ; Don't rename unused block arguments.
@@ -237,7 +242,8 @@ If FILE is not found in DIRECTORY, the parent of DIRECTORY will be searched."
                          "--auto-correct"
                          "--format" "emacs")))
 
-    (if (rubocopfmt--bundled-path-p src-dir)
+    (if (and rubocopfmt-use-bundler-when-possible
+             (rubocopfmt--bundled-path-p src-dir))
         (setq fmt-command "bundle"
               fmt-args (append (list "exec" rubocopfmt-rubocop-command)
                                fmt-args)))


### PR DESCRIPTION
For some projects I don't have bundler as part of the Gemfile but run it
as an external tool. With this kind of setup it would be nice to be able
to opt out of `bundle exec` even if you have a Gemfile and are using
bundler for the rest of the project.