### PR TITLE
Add support for ruby-ts-mode

### DIFF
--- a/rubocopfmt.el
+++ b/rubocopfmt.el
@@ -95,7 +95,7 @@ Determines if --autocorrect or --autocorrect-all will be passed to rubocop."
   :type 'boolean
   :group 'rubocopfmt)
 
-(defcustom rubocopfmt-major-modes '(ruby-mode enh-ruby-mode)
+(defcustom rubocopfmt-major-modes '(ruby-mode ruby-ts-mode enh-ruby-mode)
   "List of major modes to format on save when rubocopfmt-mode is enabled."
   :type '(repeat symbol)
   :group 'rubocopfmt)


### PR DESCRIPTION
With Emacs 29 around the corner, `ruby-ts-mode` is the new treesitter based Ruby major mode. I think it would be nice if it could become a first-class citizen with `rubocopfmt`
